### PR TITLE
BUGFIX: Should only disable the Go instance if there are no more tweens

### DIFF
--- a/Assets/Plugins/GoKit/Go.cs
+++ b/Assets/Plugins/GoKit/Go.cs
@@ -301,8 +301,11 @@ public class Go : MonoBehaviour
 		{
 			_tweens.Remove( tween );
 			
-			// disable ourself if we have no more tweens
-			_instance.enabled = false;
+			if (_tweens.Count == 0)
+			{
+				// disable ourself if we have no more tweens
+				_instance.enabled = false;
+			}
 			
 			return true;
 		}


### PR DESCRIPTION
Any tween that was removed disabled the Go instance, which caused tweens to be left half-executed
