### PR TITLE
Small fix for Tween.cs

### DIFF
--- a/Assets/Plugins/GoKit/Tween.cs
+++ b/Assets/Plugins/GoKit/Tween.cs
@@ -131,8 +131,11 @@ public class Tween : AbstractTween
 		var convertedElapsedTime = _isLoopingBackOnPingPong ? duration - _elapsedTime : _elapsedTime;
 		
 		// update all properties
-		for( var i = 0; i < _tweenPropertyList.Count; i++ )
-			_tweenPropertyList[i].tick( convertedElapsedTime );
+		if (_tweenPropertyList != null)
+		{
+			for( var i = 0; i < _tweenPropertyList.Count; i++ )
+				_tweenPropertyList[i].tick( convertedElapsedTime );
+		}
 		
 		return baseResult;
 	}


### PR DESCRIPTION
Small fix to prevent Tween.update() from accessing _tweenPropertyList on last update (in case of tween are done) and throwing null reference exception.
