### PR TITLE
Fix for UpdateType.TimeScaleIndependentUpdate not working

### DIFF
--- a/Assets/Plugins/GoKit/Go.cs
+++ b/Assets/Plugins/GoKit/Go.cs
@@ -109,7 +109,7 @@ public class Go : MonoBehaviour
     private IEnumerator timeScaleIndependentUpdate()
     {
 		_timeScaleIndependentUpdateIsRunning = true;
-		var time = 0f;
+		var time = Time.realtimeSinceStartup;
 		
         while( _tweens.Count > 0 )
         {


### PR DESCRIPTION
Fixed TimeScaleIndependentUpdate not working due to the initial elapsed time being very large because the previousTime value was set to 0f instead of Time.realtimeSinceStartup.
