### PR TITLE
Added config class for tween collections, fixes independent time scale issues with them.

### DIFF
--- a/Assets/Demo/scripts/TweenChainGUI.cs
+++ b/Assets/Demo/scripts/TweenChainGUI.cs
@@ -19,7 +19,7 @@ public class TweenChainGUI : BaseDemoGUI
 			.setIterations( 2, GoLoopType.PingPong ); // 2 iterations with a PingPong loop so we go out and back
 		
 		// create the chain and set it to have 2 iterations
-		var chain = new GoTweenChain().setIterations( 2 );
+		var chain = new GoTweenChain(new GoTweenCollectionConfig().setIterations( 2 ));
 		
 		// add a completion handler for the chain
 		chain.setOnCompleteHandler( c => Debug.Log( "chain complete" ) );

--- a/Assets/Demo/scripts/TweenFlowGUI.cs
+++ b/Assets/Demo/scripts/TweenFlowGUI.cs
@@ -23,7 +23,7 @@ public class TweenFlowGUI : BaseDemoGUI
 			.setIterations( 2, GoLoopType.PingPong ); // 2 iterations with a PingPong loop so we go out and back;
 		
 		// create the flow and set it to have 2 iterations
-		var flow = new GoTweenFlow().setIterations( 2 );
+		var flow = new GoTweenFlow(new GoTweenCollectionConfig().setIterations( 2 ));
 		
 		// add a completion handler for the chain
 		flow.setOnCompleteHandler( c => Debug.Log( "flow complete" ) );

--- a/Assets/Plugins/GoKit/GoTweenChain.cs
+++ b/Assets/Plugins/GoKit/GoTweenChain.cs
@@ -4,43 +4,9 @@ using System.Collections;
 
 public class GoTweenChain : AbstractGoTweenCollection
 {
-	public GoTweenChain() : base()
-	{}
-	
-	
-	#region chained property setters
-	
-	public GoTweenChain setId( int id )
-	{
-		this.id = id;
-		return this;
-	}
+	public GoTweenChain() : this(new GoTweenCollectionConfig()) {}
+	public GoTweenChain(GoTweenCollectionConfig config) : base(config) {}
 
-	
-	public GoTweenChain setIterations( int iterations )
-	{
-		this.iterations = iterations;
-		return this;
-	}
-	
-	
-	public GoTweenChain setIterations( int iterations, GoLoopType loopType )
-	{
-		this.iterations = iterations;
-		this.loopType = loopType;
-		return this;
-	}
-
-	
-	public GoTweenChain setUpdateType( GoUpdateType updateType )
-	{
-		this.updateType = updateType;
-		return this;
-	}
-	
-	#endregion
-
-	
 	#region internal Chain management
 	
 	private void append( TweenFlowItem item )

--- a/Assets/Plugins/GoKit/GoTweenCollectionConfig.cs
+++ b/Assets/Plugins/GoKit/GoTweenCollectionConfig.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+
+public class GoTweenCollectionConfig
+{
+	public int id; // id for finding the Tween at a later time. multiple Tweens can have the same id
+	public int iterations = 1; // number of times to iterate. -1 will loop indefinitely
+	public GoLoopType loopType = Go.defaultLoopType;
+	public GoUpdateType propertyUpdateType = Go.defaultUpdateType;
+	public Action<AbstractGoTween> onCompleteHandler;
+	public Action<AbstractGoTween> onStartHandler;
+
+	
+	/// <summary>
+	/// sets the number of iterations. setting to -1 will loop infinitely
+	/// </summary>
+	public GoTweenCollectionConfig setIterations( int iterations )
+	{
+		this.iterations = iterations;
+		return this;
+	}
+	
+	
+	/// <summary>
+	/// sets the number of iterations and the loop type. setting to -1 will loop infinitely
+	/// </summary>
+	public GoTweenCollectionConfig setIterations( int iterations, GoLoopType loopType )
+	{
+		this.iterations = iterations;
+		this.loopType = loopType;
+		return this;
+	}
+	
+	
+	/// <summary>
+	/// sets the update type for the Tween
+	/// </summary>
+	public GoTweenCollectionConfig setUpdateType( GoUpdateType setUpdateType )
+	{
+		this.propertyUpdateType = setUpdateType;
+		return this;
+	}
+	
+	
+	/// <summary>
+	/// sets the onComplete handler for the Tween
+	/// </summary>
+	public GoTweenCollectionConfig onComplete( Action<AbstractGoTween> onComplete )
+	{
+		onCompleteHandler = onComplete;
+		return this;
+	}
+	
+	
+	/// <summary>
+	/// sets the onStart handler for the Tween
+	/// </summary>
+	public GoTweenCollectionConfig onStart( Action<AbstractGoTween> onStart )
+	{
+		onStartHandler = onStart;
+		return this;
+	}
+	
+	
+	/// <summary>
+	/// sets the id for the Tween. Multiple Tweens can have the same id and you can retrieve them with the Go class
+	/// </summary>
+	public GoTweenCollectionConfig setId( int id )
+	{
+		this.id = id;
+		return this;
+		
+	}
+
+}

--- a/Assets/Plugins/GoKit/GoTweenFlow.cs
+++ b/Assets/Plugins/GoKit/GoTweenFlow.cs
@@ -9,42 +9,8 @@ using System.Collections;
 /// </summary>
 public class GoTweenFlow : AbstractGoTweenCollection
 {
-	public GoTweenFlow() : base()
-	{}
-	
-	
-	#region chained property setters
-	
-	public GoTweenFlow setId( int id )
-	{
-		this.id = id;
-		return this;
-	}
-
-	
-	public GoTweenFlow setIterations( int iterations )
-	{
-		this.iterations = iterations;
-		return this;
-	}
-	
-	
-	public GoTweenFlow setIterations( int iterations, GoLoopType loopType )
-	{
-		this.iterations = iterations;
-		this.loopType = loopType;
-		return this;
-	}
-
-	
-	public GoTweenFlow setUpdateType( GoUpdateType updateType )
-	{
-		this.updateType = updateType;
-		return this;
-	}
-	
-	#endregion
-	
+	public GoTweenFlow() : this(new GoTweenCollectionConfig()) {}
+	public GoTweenFlow(GoTweenCollectionConfig config) : base(config) {}
 	
 	#region internal Flow management
 	

--- a/Assets/Plugins/GoKit/base/AbstractGoTweenCollection.cs
+++ b/Assets/Plugins/GoKit/base/AbstractGoTweenCollection.cs
@@ -37,15 +37,19 @@ public class AbstractGoTweenCollection : AbstractGoTween
 
 	}
 	
-	
-	public AbstractGoTweenCollection()
-	{
+	public AbstractGoTweenCollection(GoTweenCollectionConfig config) {
+		// copy the TweenConfig info over
+		id = config.id;
+		loopType = config.loopType;
+		iterations = config.iterations;
+		updateType = config.propertyUpdateType;
+		_onComplete = config.onCompleteHandler;
+		_onStart = config.onStartHandler;
 		timeScale = 1;
-		iterations = 1;
 		state = GoTweenState.Paused;
 		Go.addTween( this );
 	}
-	
+		
 	
 	#region AbstractTween overrides
 	


### PR DESCRIPTION
Classes inheriting from AbstractGoTweenCollection were unable to make use of timeScaleIndependantUpdateType because this could only be set after the constructor was called (which adds the collection to the Go class update loop as a normal Update).

Using a config class allows this, and other parameters to be set upon construction in the same manner as the GoTween class thus making it more consistent, and fixing the timescale bug. Two birds, one stone.
