### PR TITLE
A fix to stop multiple GoKit instances building up in a scene.

### DIFF
--- a/Assets/Plugins/GoKit/Go.cs
+++ b/Assets/Plugins/GoKit/Go.cs
@@ -18,17 +18,22 @@ public class Go : MonoBehaviour
 	// validates that the target object still exists each tick of the tween. NOTE: it is recommended
 	// that you just properly remove your tweens before destroying any objects even though this might destroy them for you
 	public static bool validateTargetObjectsEachTick = true;
-	
+
+	// Used to stop instances being created while the application is quitting
+	private static bool _applicationIsQuitting = false;
+
 	private static List<AbstractGoTween> _tweens = new List<AbstractGoTween>(); // contains Tweens, TweenChains and TweenFlows
 	private bool _timeScaleIndependentUpdateIsRunning;
-	
+
 	// only one Go can exist
 	static Go _instance = null;
 	public static Go instance
 	{
 		get
 		{
-			if( !_instance )
+			// Don't allow new instances to be created when the application is quitting to avoid the GOKit object never being destroyed.
+			// These dangling instances can't be found with FindObjectOfType and so you'd get multiple instances in a scene.
+			if( !_instance && !_applicationIsQuitting )
 			{
 				// check if there is a GO instance already available in the scene graph
 				_instance = FindObjectOfType( typeof( Go ) ) as Go;
@@ -108,6 +113,7 @@ public class Go : MonoBehaviour
 	{
 		_instance = null;
 		Destroy( gameObject );
+		_applicationIsQuitting = true;
 	}
 	
 	#endregion


### PR DESCRIPTION
The issue is that as the application is quitting, the GoKit instance is destroyed and then GoKit.instance is referred to again, causing a new instance is created. This new instance is serialised with the scene and can't be found back with FindObjectOfType(). The side effect of multiple instances is that tweens run faster because they tick more then once a frame.

This fix simply marks when the application is quitting and doesn't allow another instance to be created.

I see by the comments on commit 6909712, you've had issues with this. This should help!
