### PR TITLE
Catch null reference exception when removing tweens while quitting

### DIFF
--- a/Assets/Plugins/GoKit/Go.cs
+++ b/Assets/Plugins/GoKit/Go.cs
@@ -9,12 +9,12 @@ public class Go : MonoBehaviour
 	public static GoEaseType defaultEaseType = GoEaseType.Linear;
 	public static GoLoopType defaultLoopType = GoLoopType.RestartFromBeginning;
 	public static GoUpdateType defaultUpdateType = GoUpdateType.Update;
-	
+
 	// defines what we should do in the event that a TweenProperty is added and an already existing tween has the same
 	// property and target
 	public static GoDuplicatePropertyRuleType duplicatePropertyRule = GoDuplicatePropertyRuleType.None;
 	public static GoLogLevel logLevel = GoLogLevel.Warn;
-	
+
 	// validates that the target object still exists each tick of the tween. NOTE: it is recommended
 	// that you just properly remove your tweens before destroying any objects even though this might destroy them for you
 	public static bool validateTargetObjectsEachTick = true;
@@ -37,7 +37,7 @@ public class Go : MonoBehaviour
 			{
 				// check if there is a GO instance already available in the scene graph
 				_instance = FindObjectOfType( typeof( Go ) ) as Go;
-				
+
 				// possible Unity bug with FindObjectOfType workaround
 				//_instance = FindObjectOfType( typeof( Go ) ) ?? GameObject.Find( "GoKit" ).GetComponent<Go>() as Go;
 
@@ -53,8 +53,8 @@ public class Go : MonoBehaviour
 			return _instance;
 		}
 	}
-	
-	
+
+
 	/// <summary>
 	/// loops through all the Tweens and updates any that are of updateType. If any Tweens are complete
 	/// (the update call will return true) they are removed.
@@ -65,7 +65,7 @@ public class Go : MonoBehaviour
 		for( var i = _tweens.Count - 1; i >= 0; --i )
 		{
 			var t = _tweens[i];
-			
+
 			// only process tweens with our update type that are running
 			if( t.updateType == updateType && t.state == GoTweenState.Running && t.update( deltaTime * t.timeScale ) )
 			{
@@ -78,47 +78,47 @@ public class Go : MonoBehaviour
 			}
 		}
 	}
-	
-	
+
+
 	#region Monobehaviour
 
 	private void Update()
 	{
 		if( _tweens.Count == 0 )
 			return;
-		
+
 		handleUpdateOfType( GoUpdateType.Update, Time.deltaTime );
 	}
-	
-	
+
+
 	private void LateUpdate()
 	{
 		if( _tweens.Count == 0 )
 			return;
-		
+
 		handleUpdateOfType( GoUpdateType.LateUpdate, Time.deltaTime );
 	}
 
-	
+
 	private void FixedUpdate()
 	{
 		if( _tweens.Count == 0 )
 			return;
-		
+
 		handleUpdateOfType( GoUpdateType.FixedUpdate, Time.deltaTime );
 	}
-	
-	
+
+
 	private void OnApplicationQuit()
 	{
 		_instance = null;
 		Destroy( gameObject );
 		_applicationIsQuitting = true;
 	}
-	
+
 	#endregion
-	
-	
+
+
     /// <summary>
     /// this only runs as needed and handles time scale independent Tweens
     /// </summary>
@@ -126,7 +126,7 @@ public class Go : MonoBehaviour
     {
 		_timeScaleIndependentUpdateIsRunning = true;
 		var time = Time.realtimeSinceStartup;
-		
+
         while( _tweens.Count > 0 )
         {
             var elapsed = Time.realtimeSinceStartup - time;
@@ -137,11 +137,11 @@ public class Go : MonoBehaviour
 
             yield return null;
         }
-		
+
 		_timeScaleIndependentUpdateIsRunning = false;
     }
-	
-	
+
+
 	/// <summary>
 	/// checks for duplicate properties. if one is found and the DuplicatePropertyRuleType is set to
 	/// DontAddCurrentProperty it will return true indicating that the tween should not be added.
@@ -154,9 +154,9 @@ public class Go : MonoBehaviour
 
 		// store a list of all the properties in the tween
 		var allProperties = tween.allTweenProperties();
-		
+
 		// TODO: perhaps only perform the check on running Tweens?
-		
+
 		// loop through all the tweens with the same target
 		foreach( var tweenWithTarget in allTweensWithTarget )
 		{
@@ -164,7 +164,7 @@ public class Go : MonoBehaviour
 			foreach( var tweenProp in allProperties )
 			{
 				warn( "found duplicate TweenProperty {0} in tween {1}", tweenProp, tween );
-				
+
 				// check for a matched property
 				if( tweenWithTarget.containsTweenProperty( tweenProp ) )
 				{
@@ -178,18 +178,18 @@ public class Go : MonoBehaviour
 						// TODO: perhaps check if the Tween has any properties left and remove it if it doesnt?
 						tweenWithTarget.removeTweenProperty( tweenProp );
 					}
-					
+
 					return false;
 				}
 			}
 		}
-		
+
 		return false;
 	}
-	
-	
+
+
 	#region Logging
-	
+
 	/// <summary>
 	/// logging should only occur in the editor so we use a conditional
 	/// </summary>
@@ -201,8 +201,8 @@ public class Go : MonoBehaviour
 		else
 			Debug.Log( format );
 	}
-	
-	
+
+
 	[System.Diagnostics.Conditional( "UNITY_EDITOR" )]
 	public static void warn( object format, params object[] paramList )
 	{
@@ -214,8 +214,8 @@ public class Go : MonoBehaviour
 		else
 			Debug.LogWarning( format );
 	}
-	
-	
+
+
 	[System.Diagnostics.Conditional( "UNITY_EDITOR" )]
 	public static void error( object format, params object[] paramList )
 	{
@@ -227,12 +227,12 @@ public class Go : MonoBehaviour
 		else
 			Debug.LogError( format );
 	}
-	
+
 	#endregion
 
-	
+
 	#region public API
-	
+
 	/// <summary>
 	/// helper function that creates a "to" Tween and adds it to the pool
 	/// </summary>
@@ -243,8 +243,8 @@ public class Go : MonoBehaviour
 
 		return tween;
 	}
-	
-	
+
+
 	/// <summary>
 	/// helper function that creates a "from" Tween and adds it to the pool
 	/// </summary>
@@ -253,11 +253,11 @@ public class Go : MonoBehaviour
 		config.setIsFrom();
 		var tween = new GoTween( target, duration, config );
 		addTween( tween );
-		
+
 		return tween;
 	}
-	
-	
+
+
 	/// <summary>
 	/// adds an AbstractTween (Tween, TweenChain or TweenFlow) to the current list of running Tweens
 	/// </summary>
@@ -266,43 +266,43 @@ public class Go : MonoBehaviour
 		// early out for invalid items
 		if( !tween.isValid() )
 			return;
-		
+
 		// dont add the same tween twice
 		if( _tweens.Contains( tween ) )
 			return;
-		
+
 		// check for dupes and handle them before adding the tween. we only need to check for Tweens
 		if( duplicatePropertyRule != GoDuplicatePropertyRuleType.None && tween is GoTween )
 		{
 			// if handleDuplicatePropertiesInTween returns true it indicates we should not add this tween
 			if( handleDuplicatePropertiesInTween( tween as GoTween ) )
 				return;
-			
+
 			// if we became invalid after handling dupes dont add the tween
 			if( !tween.isValid() )
 				return;
 		}
-		
+
 		_tweens.Add( tween );
 
 		// enable ourself if we are not enabled
 		if( !instance.enabled ) // purposely using the static instace property just once for initialization
 			_instance.enabled = true;
-		
+
 		// if the Tween isn't paused and it is a "from" tween jump directly to the start position
 		if( tween is GoTween && ((GoTween)tween).isFrom && tween.state != GoTweenState.Paused )
 			tween.update( 0 );
-		
+
 		// should we start up the time scale independent update?
 		if( !_instance._timeScaleIndependentUpdateIsRunning && tween.updateType == GoUpdateType.TimeScaleIndependentUpdate )
 			_instance.StartCoroutine( _instance.timeScaleIndependentUpdate() );
-		
+
 #if UNITY_EDITOR
 		_instance.gameObject.name = string.Format( "GoKit ({0} tweens)", _tweens.Count );
 #endif
 	}
-	
-	
+
+
 	/// <summary>
 	/// removes the Tween returning true if it was removed or false if it was not found
 	/// </summary>
@@ -311,32 +311,32 @@ public class Go : MonoBehaviour
 		if( _tweens.Contains( tween ) )
 		{
 			_tweens.Remove( tween );
-			
+
 #if UNITY_EDITOR
 		if( _instance != null && _tweens != null )
 			_instance.gameObject.name = string.Format( "GoKit ({0} tweens)", _tweens.Count );
 #endif
-			
-			if( _tweens.Count == 0 )
+
+			if( _instance!=null && _tweens.Count == 0 )
 			{
 				// disable ourself if we have no more tweens
-				instance.enabled = false;
+				_instance.enabled = false;
 			}
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
-	
-	
+
+
 	/// <summary>
 	/// returns a list of all Tweens, TweenChains and TweenFlows with the given id
 	/// </summary>
 	public static List<AbstractGoTween> tweensWithId( int id )
 	{
 		List<AbstractGoTween> list = null;
-		
+
 		foreach( var tween in _tweens )
 		{
 			if( tween.id == id )
@@ -346,11 +346,11 @@ public class Go : MonoBehaviour
 				list.Add( tween );
 			}
 		}
-		
+
 		return list;
 	}
-	
-	
+
+
 	/// <summary>
 	/// returns a list of all Tweens with the given target. TweenChains and TweenFlows can optionally
 	/// be traversed and matching Tweens returned as well.
@@ -358,14 +358,14 @@ public class Go : MonoBehaviour
 	public static List<GoTween> tweensWithTarget( object target, bool traverseCollections = false )
 	{
 		List<GoTween> list = new List<GoTween>();
-		
+
 		foreach( var item in _tweens )
 		{
 			// we always check Tweens so handle them first
 			var tween = item as GoTween;
 			if( tween != null && tween.target == target )
 				list.Add( tween );
-			
+
 			// optionally check TweenChains and TweenFlows. if tween is null we have a collection
 			if( traverseCollections && tween == null )
 			{
@@ -378,11 +378,11 @@ public class Go : MonoBehaviour
 				}
 			}
 		}
-		
+
 		return list;
 	}
-	
-	
+
+
 	/// <summary>
 	/// kills all tweens with the given target by calling the destroy method on each one
 	/// </summary>
@@ -391,7 +391,7 @@ public class Go : MonoBehaviour
 		foreach( var tween in tweensWithTarget( target, true ) )
 			tween.destroy();
 	}
-	
+
 	#endregion
 
 }


### PR DESCRIPTION
Now that the instance isn't recreated while the app is quitting, users can get a crash by trying to remove tweens on app quit. This change protects against referencing the deleted instance.

I also changed it so the instance is disabled via the field not the property to be consistent with the rest of the class.
