### PR TITLE
Updates to GoTween.cs to include a string to help debug when the tween target is destroyed.

### DIFF
--- a/Assets/Plugins/GoKit/GoTween.cs
+++ b/Assets/Plugins/GoKit/GoTween.cs
@@ -47,7 +47,7 @@ public class GoTween : AbstractGoTween
 		autoRemoveOnComplete = true;
 		
 		this.target = target;
-		this.targetString = target.GetType().ToString();
+		this.targetTypeString = target.GetType().ToString();
 		this.duration = duration;
 		
 		// copy the TweenConfig info over


### PR DESCRIPTION
This change greatly helps when debugging destroyed tween targets. It helps understand the type of the object that is affected by the tween warning.
