### PR TITLE
Fix to ArgumentOutOfRangeException in handleUpdateOfType

### DIFF
--- a/Assets/Plugins/GoKit/Go.cs
+++ b/Assets/Plugins/GoKit/Go.cs
@@ -66,14 +66,18 @@ public class Go : MonoBehaviour
 		{
 			var t = _tweens[i];
 
-			// only process tweens with our update type that are running
-			if( t.updateType == updateType && t.state == GoTweenState.Running && t.update( deltaTime * t.timeScale ) )
-			{
-				// tween is complete if we get here. if destroyed or set to auto remove kill it
-				if( t.state == GoTweenState.Destroyed || t.autoRemoveOnComplete )
+			if( t.state == GoTweenState.Destroyed ) { // destroy method has been called
+				removeTween( t );
+			} else {
+				// only process tweens with our update type that are running
+				if( t.updateType == updateType && t.state == GoTweenState.Running && t.update( deltaTime * t.timeScale ) )
 				{
-					removeTween( t );
-					t.destroy();
+					// tween is complete if we get here. if destroyed or set to auto remove kill it
+					if( t.state == GoTweenState.Destroyed || t.autoRemoveOnComplete )
+					{
+						removeTween( t );
+						t.destroy();
+					}
 				}
 			}
 		}

--- a/Assets/Plugins/GoKit/base/AbstractGoTween.cs
+++ b/Assets/Plugins/GoKit/base/AbstractGoTween.cs
@@ -188,7 +188,7 @@ public abstract class AbstractGoTween
 	public virtual void destroy()
 	{
 		state = GoTweenState.Destroyed;
-		Go.removeTween( this );
+		//Go.removeTween( this ); //this done now in Go.handleUpdateOfType to avoid removing a tween while they are parsed in the main loop
 	}
 
 	


### PR DESCRIPTION
In Go.handleUpdateOfType, if you remove/destroy a tween B in the onComplete method of a tween A, you sometimes get a ArgumentOutOfRangeException on the line 'var t = _tweens[i];'.
And I suppose that sometimes you don't get the Exception but you skip a tween.update() in the loop.

The fix I submitted here is to not remove immediately the tween when you call destroy() on it. It will be removed in the main loop in the Go class.
