### PR TITLE
Bug fix for AbstractGoTweenCollection

### DIFF
--- a/Assets/Plugins/GoKit/base/AbstractGoTweenCollection.cs
+++ b/Assets/Plugins/GoKit/base/AbstractGoTweenCollection.cs
@@ -174,6 +174,9 @@ public class AbstractGoTweenCollection : AbstractGoTween
 				}
 			}
 			
+			if( !_didComplete )
+				onComplete();			
+			
 			return true; //true if complete
 
 		} else {


### PR DESCRIPTION
The last update to AbstractGoTweenCollection removed the check for calling the onComplete for the collection, breaking existing functionality.

I've updated the newer logic to include the call to the onComplete handler while maintaining the previous fix as well.
