### PR TITLE
Fixed two bugs in the GoDummyPathEditor

### DIFF
--- a/Assets/Editor/GoDummyPathEditor.cs
+++ b/Assets/Editor/GoDummyPathEditor.cs
@@ -196,9 +196,10 @@ public class GoDummyPathEditor : Editor
 		_showNodeDetails = EditorGUILayout.Foldout( _showNodeDetails, "Show Node Values" );
 		if( _showNodeDetails )
 		{
-			EditorGUI.indentLevel = 3;
+			EditorGUI.indentLevel++;
 			for( int i = 0; i < _target.nodes.Count; i++ )
 				_target.nodes[i] = EditorGUILayout.Vector3Field( "Node " + ( i + 1 ), _target.nodes[i] );
+			EditorGUI.indentLevel--;
 		}
 		
 		


### PR DESCRIPTION
- user could delete one of the two last nodes and render the component unusable, forcing him to re-add the component
- nodes list editor indent was set to too high and was not reset after rendering the node list forcing the help box to have the indentation applied as well when nodes list is folded out
