### PR TITLE
Fixed GoDummyPathEditor bug with using the "Shift path to start at origin" feature

### DIFF
--- a/Assets/Editor/GoDummyPathEditor.cs
+++ b/Assets/Editor/GoDummyPathEditor.cs
@@ -125,7 +125,7 @@ public class GoDummyPathEditor : Editor
 			
 			// see what kind of path we are. the simplest case is just a straight line
 			var path = new GoSpline( _target.nodes, _target.forceStraightLinePath );
-			if( path.splineType == GoSplineType.StraightLine )
+			if( path.splineType == GoSplineType.StraightLine || _target.nodes.Count < 5 )
 				offset = Vector3.zero - _target.nodes[0];
 			else
 				offset = Vector3.zero - _target.nodes[1];


### PR DESCRIPTION
- using the `Shift path to start at origin` feature would give unexpected results when used against paths using solvers other than CatmullRom solver (less then 5 nodes) with wrong node being set as the origin.
