### PR TITLE
Fixed bug in GoSplineCubicBezierSolver where reversing path with 4 nodes would give unexpected results

### DIFF
--- a/Assets/Plugins/GoKit/properties/splines/GoSplineCubicBezierSolver.cs
+++ b/Assets/Plugins/GoKit/properties/splines/GoSplineCubicBezierSolver.cs
@@ -25,7 +25,7 @@ public class GoSplineCubicBezierSolver : AbstractGoSplineSolver
 	public override Vector3 getPoint( float t )
 	{
 		float d = 1f - t;
-		return d * d * d * _nodes[0] + 3f * d * d * t * _nodes[2] + 3f * d * t * t * _nodes[3] + t * t * t * _nodes[1];
+		return d * d * d * _nodes[0] + 3f * d * d * t * _nodes[1] + 3f * d * t * t * _nodes[2] + t * t * t * _nodes[3];
 	}
 
 	
@@ -35,8 +35,8 @@ public class GoSplineCubicBezierSolver : AbstractGoSplineSolver
 		var originalColor = Gizmos.color;
 		Gizmos.color = Color.red;
 		
-		Gizmos.DrawLine( _nodes[0], _nodes[2] );
-		Gizmos.DrawLine( _nodes[3], _nodes[1] );
+		Gizmos.DrawLine( _nodes[0], _nodes[1] );
+		Gizmos.DrawLine( _nodes[2], _nodes[3] );
 		
 		Gizmos.color = originalColor;
 	}


### PR DESCRIPTION
- reversing a path with 4 nodes would give unexpected results (messed up mirroring instead of reversing) because of the nodes order being mixed up - automatically fixes it for the GoDummyPathEditor which uses the solver for drawing. Also changing the order of nodes will make it follow the standard bezier curve nodes indexing

note: if somebody was hacking something with paths and was reading 2nd node as the end node rather then last node being the end node as it would be now it could be a breaking change. For the standard use of the GoKit library it shouldn't cause any problems . Saved paths using 4 nodes would most likely requiring small tweaking. Alternative would be to implement custom node reversing method for cubic bezier solver and in the GoDummyPathEditor but it feels wrong to go this way.
