### PR TITLE
fixed build error for windows phone 8

### DIFF
--- a/Assets/Plugins/GoKit/properties/splines/GoSpline.cs
+++ b/Assets/Plugins/GoKit/properties/splines/GoSpline.cs
@@ -91,7 +91,7 @@ public class GoSpline
 			path = Path.Combine( Path.Combine( Application.dataPath, "StreamingAssets" ), pathAssetName );
 		}
 		
-#if UNITY_WEBPLAYER || NETFX_CORE
+#if UNITY_WEBPLAYER || NETFX_CORE || UNITY_WP8
 		// it isnt possible to get here but the compiler needs it to be here anyway
 		return null;
 #else


### PR DESCRIPTION
System.IO.File.ReadAllBytes is not available on windows phone 8 and prevents gokit from building. 
