### PR TITLE
Added AnimationCurve ease type

### DIFF
--- a/Assets/Plugins/GoKit/GoTween.cs
+++ b/Assets/Plugins/GoKit/GoTween.cs
@@ -36,6 +36,10 @@ public class GoTween : AbstractGoTween
         }
     }
 
+    /// <summary>
+    /// sets the ease curve for all Tweens
+    /// </summary>
+    public AnimationCurve easeCurve { get; set; }
 
 	/// <summary>
 	/// initializes a new instance and sets up the details according to the config parameter
@@ -67,6 +71,7 @@ public class GoTween : AbstractGoTween
 		loopType = config.loopType;
 		iterations = config.iterations;
 		_easeType = config.easeType;
+		easeCurve = config.easeCurve;
 		updateType = config.propertyUpdateType;
 		isFrom = config.isFrom;
 		timeScale = config.timeScale;

--- a/Assets/Plugins/GoKit/GoTweenConfig.cs
+++ b/Assets/Plugins/GoKit/GoTweenConfig.cs
@@ -15,6 +15,7 @@ public class GoTweenConfig
 	public int timeScale = 1;
 	public GoLoopType loopType = Go.defaultLoopType;
 	public GoEaseType easeType = Go.defaultEaseType;
+	public AnimationCurve easeCurve;
 	public bool isPaused;
 	public GoUpdateType propertyUpdateType = Go.defaultUpdateType;
 	public bool isFrom;
@@ -410,6 +411,17 @@ public class GoTweenConfig
 		return this;
 	}
 
+
+	/// <summary>
+	/// sets the ease curve for the Tween
+	/// </summary>
+	public GoTweenConfig setEaseCurve( AnimationCurve easeCurve )
+	{
+		this.easeCurve = easeCurve;
+		this.easeType = GoEaseType.AnimationCurve;
+
+		return this;
+	}
 
 	/// <summary>
 	/// sets whether the Tween should start paused

--- a/Assets/Plugins/GoKit/easing/GoEaseAnimationCurve.cs
+++ b/Assets/Plugins/GoKit/easing/GoEaseAnimationCurve.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+using System;
+
+
+public static class GoEaseAnimationCurve
+{
+	public static Func<float, float, float, float, float> EaseCurve( GoTween tween )
+	{
+		if (tween == null)
+		{
+			Debug.LogError("no tween to extract easeCurve from");
+		}
+
+		if (tween.easeCurve == null)
+		{
+			Debug.LogError("no curve found for tween");
+		}
+
+		return delegate (float t, float b, float c, float d)
+		{
+			return tween.easeCurve.Evaluate(t / d) * c + b;
+		};
+	}
+}
+

--- a/Assets/Plugins/GoKit/easing/GoEaseAnimationCurve.cs.meta
+++ b/Assets/Plugins/GoKit/easing/GoEaseAnimationCurve.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd73519bde01d17468f1c9eedaae40f7
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/Assets/Plugins/GoKit/enums/GoEaseType.cs
+++ b/Assets/Plugins/GoKit/enums/GoEaseType.cs
@@ -46,5 +46,7 @@ public enum GoEaseType
 
     BounceIn,
     BounceOut,
-    BounceInOut
+    BounceInOut,
+
+    AnimationCurve
 }

--- a/Assets/Plugins/GoKit/properties/GoTweenUtils.cs
+++ b/Assets/Plugins/GoKit/properties/GoTweenUtils.cs
@@ -9,7 +9,7 @@ public static class GoTweenUtils
 	/// <summary>
 	/// fetches the actual function for the given ease type
 	/// </summary>
-	public static Func<float,float,float,float,float> easeFunctionForType( GoEaseType easeType )
+	public static Func<float,float,float,float,float> easeFunctionForType( GoEaseType easeType, GoTween tween = null )
 	{
 		switch( easeType )
 		{
@@ -87,6 +87,9 @@ public static class GoTweenUtils
 				return GoEaseSinusoidal.EaseOut;
 			case GoEaseType.SineInOut:
 				return GoEaseSinusoidal.EaseInOut;
+
+			case GoEaseType.AnimationCurve:
+				return GoEaseAnimationCurve.EaseCurve(tween);
 		}
 		
 		return GoEaseLinear.EaseNone;

--- a/Assets/Plugins/GoKit/properties/abstracts/AbstractTweenProperty.cs
+++ b/Assets/Plugins/GoKit/properties/abstracts/AbstractTweenProperty.cs
@@ -12,8 +12,6 @@ public abstract class AbstractTweenProperty
 	protected GoTween _ownerTween;
 	
 	protected Func<float, float, float, float, float> _easeFunction;
-	
-	
 
 	public AbstractTweenProperty( bool isRelative = false )
 	{
@@ -83,7 +81,7 @@ public abstract class AbstractTweenProperty
 	/// </summary>
 	public void setEaseType( GoEaseType easeType )
 	{
-		_easeFunction = GoTweenUtils.easeFunctionForType( easeType );
+		_easeFunction = GoTweenUtils.easeFunctionForType( easeType, _ownerTween );
 	}
 	
 	


### PR DESCRIPTION
Adds `GoEaseType.AnimationCurve` and `GoTweenConfig.setEaseCurve`, which lets you use a Unity AnimationCurve as the easing function for a tween.  Potentially useful for defining more complex ease functions and being able to dynamically modify them.
