### PR TITLE
added clone method to GoTweenConfig

### DIFF
--- a/Assets/Plugins/GoKit/GoTweenConfig.cs
+++ b/Assets/Plugins/GoKit/GoTweenConfig.cs
@@ -542,4 +542,20 @@ public class GoTweenConfig
 		return this;
 	}
 
+	/// <summary>
+	/// clones the instance
+	/// </summary>
+	public GoTweenConfig clone()
+	{
+		var other = this.MemberwiseClone() as GoTweenConfig;
+
+		other._tweenProperties = new List<AbstractTweenProperty>( 2 );
+		foreach( var tweenProp in this._tweenProperties )
+		{
+			other._tweenProperties.Add(tweenProp);
+		}
+
+		return other;
+	}
+
 }


### PR DESCRIPTION
`GoTweenConfig.clone()` lets you build on a `GoTweenConfig` instance without mutating it.

``` csharp
var config = new GoTweenConfig().scale( 3 ).setIterations( 3 );
Go.to(someTransform, 1f, config.clone().position( Vector3.one );
// doesn't translate someOtherTransform
Go.to(someOtherTransform, 1f, config.clone().rotation( Quaternion.identity );
```
