### PR TITLE
Using default parameters with abstract methods created a compiler error ...

### DIFF
--- a/Assets/Plugins/GoKit/GoTween.cs
+++ b/Assets/Plugins/GoKit/GoTween.cs
@@ -279,7 +279,7 @@ public class GoTween : AbstractGoTween
 	/// goes to the specified time clamping it from 0 to the total duration of the tween. if the tween is
 	/// not playing it will be force updated to the time specified.
 	/// </summary>
-    public override void goTo( float time , bool skipDelay = true )
+    public override void goTo( float time , bool skipDelay)
     {
         // handle delay, which is specific to Tweens
 		if( skipDelay )

--- a/Assets/Plugins/GoKit/base/AbstractGoTween.cs
+++ b/Assets/Plugins/GoKit/base/AbstractGoTween.cs
@@ -414,15 +414,18 @@ public abstract class AbstractGoTween
 		goTo( isReversed ? 0 : totalDuration, true );
 	}
 
-
+	/// <summary>
+	/// goes to the specified time clamping it from 0 to the total duration of the tween. if the tween is
+	/// not playing it can optionally be force updated to the time specified. delays are not taken into effect.
+	/// </summary>
 	public void goTo( float time )
 	{
-		goTo(time, true);
+		goTo( time, true );
 	}
 
 	/// <summary>
 	/// goes to the specified time clamping it from 0 to the total duration of the tween. if the tween is
-	/// not playing it can optionally be force updated to the time specified. delays are not taken into effect.
+	/// not playing it can optionally be force updated to the time specified.
 	/// (must be implemented by inherited classes.)
 	/// </summary>
 	public abstract void goTo( float time, bool skipDelay);

--- a/Assets/Plugins/GoKit/base/AbstractGoTween.cs
+++ b/Assets/Plugins/GoKit/base/AbstractGoTween.cs
@@ -415,12 +415,17 @@ public abstract class AbstractGoTween
 	}
 
 
+	public void goTo( float time )
+	{
+		goTo(time, true);
+	}
+
 	/// <summary>
 	/// goes to the specified time clamping it from 0 to the total duration of the tween. if the tween is
 	/// not playing it can optionally be force updated to the time specified. delays are not taken into effect.
 	/// (must be implemented by inherited classes.)
 	/// </summary>
-	public abstract void goTo( float time, bool skipDelay = true );
+	public abstract void goTo( float time, bool skipDelay);
 
 	/// <summary>
 	/// goes to the time and starts playback skipping any delays

--- a/Assets/Plugins/GoKit/base/AbstractGoTweenCollection.cs
+++ b/Assets/Plugins/GoKit/base/AbstractGoTweenCollection.cs
@@ -372,7 +372,7 @@ public class AbstractGoTweenCollection : AbstractGoTween
     /// goes to the specified time clamping it from 0 to the total duration of the tween. if the tween is
     /// not playing it will be force updated to the time specified.
     /// </summary>
-	public override void goTo( float time, bool skipDelay = true )
+	public override void goTo( float time, bool skipDelay )
     {
         time = Mathf.Clamp( time, 0f, totalDuration );
 


### PR DESCRIPTION
...when you actually code a call to that method. This should fix that while still supplying the same functionality.