### PR TITLE
Fixed Streaming Asset Path for OSX builds

### DIFF
--- a/Assets/Plugins/GoKit/properties/splines/GoSpline.cs
+++ b/Assets/Plugins/GoKit/properties/splines/GoSpline.cs
@@ -96,7 +96,7 @@ public class GoSpline
 		else
 		{
 			// in the editor we default to looking in the StreamingAssets folder
-			path = Path.Combine( Path.Combine( Application.dataPath, "StreamingAssets" ), pathAssetName );
+			path = Path.Combine( Application.streamingAssetsPath, pathAssetName );
 		}
 		
 #if UNITY_WEBPLAYER || NETFX_CORE || UNITY_WP8


### PR DESCRIPTION
The old approach to getting the streaming asset path doesn't work anymore, but there is a new API for it: Application.streamingAssetsPath. I don't have enough platforms to test on at the moment, but the surrounding code could probably be simplified in light of this.