### PR TITLE
easing uses start/diff, lerp uses start/end

### DIFF
--- a/Assets/Plugins/GoKit/properties/specificTypes/MaterialFloatTweenProperty.cs
+++ b/Assets/Plugins/GoKit/properties/specificTypes/MaterialFloatTweenProperty.cs
@@ -54,10 +54,9 @@ public class MaterialFloatTweenProperty : AbstractMaterialFloatTweenProperty
 	
 	public override void tick( float totalElapsedTime )
 	{
-		var easedTime = _easeFunction( totalElapsedTime, 0, 1, _ownerTween.duration );
-		var value = Mathf.Lerp( _startValue, _diffValue, easedTime );
+		var easedValue = _easeFunction( totalElapsedTime, _startValue, _diffValue, _ownerTween.duration );
 		
-		_target.SetFloat( _materialPropertyName, value );
+		_target.SetFloat( _materialPropertyName, easedValue );
 	}
 
 }


### PR DESCRIPTION
What was meant for tick() is probably
		var easedTime = _easeFunction( totalElapsedTime, 0, 1, _ownerTween.duration );
		var value = Mathf.Lerp( _startValue, _startValue + _diffValue, easedTime );
		
but  the equivalent form
		var easedValue = _easeFunction( totalElapsedTime, _startValue, _diffValue, _ownerTween.duration );
		
is used elsewhere (FloatTweenProperty), and more succinct.