### PR TITLE
Replace WWW with UnityWebRequest in GoSpline.cs

### DIFF
--- a/Assets/Plugins/GoKit/properties/splines/GoSpline.cs
+++ b/Assets/Plugins/GoKit/properties/splines/GoSpline.cs
@@ -83,10 +83,10 @@ public class GoSpline
 		{
 			path = Path.Combine( "jar:file://" + Application.dataPath + "!/assets/", pathAssetName );
 		
-			WWW loadAsset = new WWW( path );
+			UnityWebRequest loadAsset = new UnityWebRequest( path );
 			while( !loadAsset.isDone ) { } // maybe make a safety check here
 			
-			return bytesToVector3List( loadAsset.bytes );
+			return bytesToVector3List( loadAsset.downloadHandler.data );
 		}
 		else if( Application.platform == RuntimePlatform.IPhonePlayer )
 		{


### PR DESCRIPTION
WWW is deprecated. UnityWebRequest is now the way to request data from a URL.

See the docs for:
  - WWW: https://docs.unity3d.com/ScriptReference/WWW-ctor.html
  - UnityWebRequest: https://docs.unity3d.com/ScriptReference/Networking.UnityWebRequest.html